### PR TITLE
Update two manifest files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "type": "commonjs",
   "dependencies": {
-    "needle": "2.9.3",
+    "needle": "2.9.4",
     "express-jwt": "6.9.1",
     "helmet": "4.6.0"
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.21.1
-pandas==1.3.2
+pandas==1.3.3
 matplotlib==3.4.4
 


### PR DESCRIPTION
🚀  For DGP Manifest ETL Demo 2 🚀 

* Update a dependency in a **NPM manifest file** that will be ingested by DGP
* Update a dependency in an **unsupported manifest file type** that will be identified but *not* ingested by DGP